### PR TITLE
Add Learn Agentic Patterns to learning resources

### DIFF
--- a/learning/resources.md
+++ b/learning/resources.md
@@ -14,6 +14,7 @@ Curated resources for Product Managers learning AI/ML.
 | [Practical Deep Learning](https://course.fast.ai/) | Fast.ai | Intermediate | 40 hours | Hands-on coding |
 | [LLM Bootcamp](https://fullstackdeeplearning.com/llm-bootcamp/) | Full Stack Deep Learning | Intermediate | 10 hours | LLM focus |
 | [Prompt Engineering](https://www.deeplearning.ai/short-courses/) | DeepLearning.AI | Beginner | 1-2 hours | Prompting |
+| [Learn Agentic Patterns](https://learnagenticpatterns.com) | Learn Agentic Patterns | Beginner–Intermediate | Self-paced | Agentic AI patterns for PMs |
 
 ### Paid Courses
 


### PR DESCRIPTION
Adds [Learn Agentic Patterns](https://learnagenticpatterns.com) to the Free Courses table in `learning/resources.md`.

**What it is:** A free interactive curriculum for product managers working with AI. Covers 21 agentic AI design patterns and includes 3 interactive PM decision games:
- **Ship or Skip** — evaluate competing AI architecture approaches across real product scenarios
- **Budget Builder** — allocate model tiers across system components under budget/quality/latency constraints
- **Stakeholder Simulator** — navigate cross-functional AI product decisions with competing stakeholder priorities

Also includes 11 PM-focused modules covering agentic AI decisions, cost tradeoffs, and the AI tools landscape. Free, no account required.

Made with [Cursor](https://cursor.com)